### PR TITLE
chore(release): skip 3.9.8 and republish bug fixes as 3.9.9

### DIFF
--- a/.changeset/fix-find-root-block-validation.md
+++ b/.changeset/fix-find-root-block-validation.md
@@ -1,0 +1,13 @@
+---
+'@maticnetwork/maticjs': patch
+---
+
+Harden `RootChain.findRootBlockFromChild` so it cannot return a checkpoint slot that doesn't actually contain the burn block.
+
+Two related issues, both fixed:
+
+- The binary search's single-candidate early exit (`start.eq(end)`) accepted the converged slot without verifying its range contained the child block. When a burn block sat past every existing checkpoint, the search would converge on `currentHeaderBlock / 10000` and silently return that slot — producing a proof that embedded an unrelated or non-existent header. On-chain MPT verification then reverted at submission time. The fix verifies `headerStart ≤ child ≤ headerEnd` for the converged candidate and throws `Burn transaction has not been checkpointed as yet` otherwise (matching the existing `isCheckPointed_` guard message). The throw also covers the case where no checkpoint has ever been submitted (`currentHeaderBlock = 0`).
+
+- `currentHeaderBlock()` and `headerBlocks(slot)` reads inside `findRootBlockFromChild` ignored `client.config.rootChainDefaultBlock`, defaulting to whatever the underlying provider used (effectively `latest`). `getLastChildBlock` already honoured the config. The two reads could therefore observe different chain views, opening a race where `isCheckPointed_` could pass against an un-finalised checkpoint that was reorged out before the proof was submitted on L1. Both reads now use the same block tag.
+
+The binary-search algorithm has been extracted into `findCheckpointSlot` for direct unit testing. It is plugin-agnostic — it consumes any `BaseBigNumber` and a constructor factory — so it works correctly with whatever BigNumber implementation the active plugin injects (`MaticBigNumber` for `@maticnetwork/maticjs-ethers`, bn.js for the web3 plugin, etc.).

--- a/.changeset/fix-receipt-bytes-canonical-rlp.md
+++ b/.changeset/fix-receipt-bytes-canonical-rlp.md
@@ -1,0 +1,9 @@
+---
+'@maticnetwork/maticjs': patch
+---
+
+Fix `ProofUtil.getReceiptBytes` so `cumulativeGasUsed = 0` encodes as the canonical RLP empty byte string (`0x80`) instead of the literal byte `0x00`.
+
+The previous encoding wrapped the integer field in `BufferUtil.toBuffer` before handing it to `rlp.encode`. For zero, that produced `<Buffer 00>`, which RLP-encodes to the single byte `0x00` — non-canonical. Bor commits `receiptsRoot` using the canonical form, so the leaf hash produced from a buggy proof never matched the root for any block whose `cumulativeGasUsed` was zero. In practice that meant **every exit proof rooted in a Bor system-tx-only block was rejected on-chain** (Plasma `ERC20PredicateBurnOnly`, Portal `MerklePatriciaProof.verify`) with `INVALID_RECEIPT_MERKLE_PROOF`, even though the API returned `200 OK`.
+
+The fix passes `cumulativeGasUsed` directly to `rlp.encode`, which canonically encodes `0` as `0x80`. Non-zero values are unaffected.

--- a/packages/maticjs/CHANGELOG.md
+++ b/packages/maticjs/CHANGELOG.md
@@ -1,19 +1,7 @@
 # @maticnetwork/maticjs
 
-## 3.9.8
-
-### Patch Changes
-
-- 6b7758a: Harden `RootChain.findRootBlockFromChild` so it cannot return a checkpoint slot that doesn't actually contain the burn block.
-
-  Two related issues, both fixed:
-  - The binary search's single-candidate early exit (`start.eq(end)`) accepted the converged slot without verifying its range contained the child block. When a burn block sat past every existing checkpoint, the search would converge on `currentHeaderBlock / 10000` and silently return that slot — producing a proof that embedded an unrelated or non-existent header. On-chain MPT verification then reverted at submission time. The fix verifies `headerStart ≤ child ≤ headerEnd` for the converged candidate and throws `Burn transaction has not been checkpointed as yet` otherwise (matching the existing `isCheckPointed_` guard message). The throw also covers the case where no checkpoint has ever been submitted (`currentHeaderBlock = 0`).
-  - `currentHeaderBlock()` and `headerBlocks(slot)` reads inside `findRootBlockFromChild` ignored `client.config.rootChainDefaultBlock`, defaulting to whatever the underlying provider used (effectively `latest`). `getLastChildBlock` already honoured the config. The two reads could therefore observe different chain views, opening a race where `isCheckPointed_` could pass against an un-finalised checkpoint that was reorged out before the proof was submitted on L1. Both reads now use the same block tag.
-
-  The binary-search algorithm has been extracted into `findCheckpointSlot` for direct unit testing. It is plugin-agnostic — it consumes any `BaseBigNumber` and a constructor factory — so it works correctly with whatever BigNumber implementation the active plugin injects (`MaticBigNumber` for `@maticnetwork/maticjs-ethers`, bn.js for the web3 plugin, etc.).
-
-- 582ded1: Fix `ProofUtil.getReceiptBytes` so `cumulativeGasUsed = 0` encodes as the canonical RLP empty byte string (`0x80`) instead of the literal byte `0x00`.
-
-  The previous encoding wrapped the integer field in `BufferUtil.toBuffer` before handing it to `rlp.encode`. For zero, that produced `<Buffer 00>`, which RLP-encodes to the single byte `0x00` — non-canonical. Bor commits `receiptsRoot` using the canonical form, so the leaf hash produced from a buggy proof never matched the root for any block whose `cumulativeGasUsed` was zero. In practice that meant **every exit proof rooted in a Bor system-tx-only block was rejected on-chain** (Plasma `ERC20PredicateBurnOnly`, Portal `MerklePatriciaProof.verify`) with `INVALID_RECEIPT_MERKLE_PROOF`, even though the API returned `200 OK`.
-
-  The fix passes `cumulativeGasUsed` directly to `rlp.encode`, which canonically encodes `0` as `0x80`. Non-zero values are unaffected.
+> **Note:** Version `3.9.8` is skipped. An earlier non-canonical
+> `changeset publish` from the `chore/monorepo` branch on 2026-03-29
+> burned `3.9.8` on npm with a build that does not correspond to any
+> release on `master` (since deprecated). The next release after `3.9.7`
+> is `3.9.9`.


### PR DESCRIPTION
## Summary

Skip `@maticnetwork/maticjs@3.9.8` and republish #465's bug fixes as 3.9.9.

3.9.8 was burned on npm 2026-03-29 by a non-canonical `changeset publish` from `chore/monorepo` (since deprecated). #468's release-flow attempt to republish 3.9.8 was correctly skipped by changesets, but the npm-release script created a phantom git tag and GitHub Release anyway. Both have been deleted.

## Changes

- Re-add #465's two changesets verbatim. Next Release / Deploy PR bumps `3.9.8 → 3.9.9` with an equivalent `## 3.9.9` CHANGELOG entry.
- Reset `CHANGELOG.md` to title + skip note. Avoids sandwiching the new entry above a phantom 3.9.8.
- Don't touch `package.json` — `runVersion` will bump it.

Empty changesets don't trigger the publish path (`changesets/action` outputs `hasChangesets='true'` for any file, including empties — verified against [run 25003368232](https://github.com/0xPolygon/matic.js/actions/runs/25003368232)), so there's no shortcut around the two-cycle release flow.

## Follow-up

[`pipelines#39`](https://github.com/0xPolygon/pipelines/pull/39) hardens `npm-release/run.sh` against the underlying "publish skipped → tag created anyway" bug.