### PR TITLE
fix(release): add prepublishOnly build hook so dist/ ships

### DIFF
--- a/.changeset/some-brooms-vanish.md
+++ b/.changeset/some-brooms-vanish.md
@@ -1,0 +1,22 @@
+---
+'@maticnetwork/maticjs': patch
+---
+
+Republish 3.9.9 as 3.9.10 with the missing `dist/` directory.
+
+3.9.9's tarball was 3 files / 2.4 KB instead of the usual ~106 files /
+4.2 MB — `dist/` is gitignored and the canonical release flow doesn't
+run a build before `changeset publish`, so the published package
+contained only `package.json`, `MIGRATION.md`, and `license.js`.
+Consumers installing 3.9.9 got a package with no compiled code.
+
+Fixed by adding `"prepublishOnly": "pnpm run build"` to
+`packages/maticjs/package.json`. `prepublishOnly` is an npm lifecycle
+hook that runs immediately before `npm publish`, so the build always
+runs regardless of which release path (canonical CI, manual local
+publish, etc.) invokes the publish.
+
+3.9.9 has been deprecated on npm; install 3.9.10 to actually receive
+the canonical RLP encoding fix and `RootChain.findRootBlockFromChild`
+hardening from
+[matic.js#465](https://github.com/0xPolygon/matic.js/pull/465).

--- a/packages/maticjs/package.json
+++ b/packages/maticjs/package.json
@@ -21,7 +21,8 @@
     "build:prod": "webpack --env build",
     "build": "pnpm run clean && pnpm run build:dev && pnpm run build:prod",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepublishOnly": "pnpm run build"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
## Summary

`@maticnetwork/maticjs@3.9.9` was published with an empty tarball — 3 files / 2.4 KB instead of the usual ~106 files / 4.2 MB. The package shipped without `dist/`, so any consumer installing it gets no compiled code (broke proof-generation-api typecheck immediately).

3.9.9 has been deprecated on npm. This PR fixes the underlying root cause and republishes as 3.9.10.

## Root cause

- `packages/maticjs/dist/` is gitignored and never committed.
- `packages/maticjs/package.json` declares `"files": ["dist", "MIGRATION.md"]` — assumes `dist/` exists at publish time.
- The canonical `apps-npm-release.yml` release job doesn't run `pnpm run build` before `changeset publish` — relies on consumers' `prepublishOnly` / `prepack` hooks.
- This package had neither hook. First real release through the canonical workflow → empty publish.

The snapshot-dispatch path on `npm-release-trigger.yml` has an explicit `pnpm --filter @maticnetwork/maticjs run build` step, which is why every snapshot we've published in this session worked correctly. The mismatch wasn't visible until the first real release went out.

## Fix

Add to `packages/maticjs/package.json`:

```json
"prepublishOnly": "pnpm run build"
```

`prepublishOnly` is an npm lifecycle hook invoked immediately before `npm publish`, so the build runs no matter which release path (canonical CI, snapshot dispatch, manual local) calls publish. Belt-and-suspenders against this recurring on any future release path.

## Test plan

- [ ] CI green
- [ ] On merge: Release / Deploy PR opens bumping `3.9.9 → 3.9.10`
- [ ] Merge that PR: workflow run shows the build executing during publish, then `Publishing "@maticnetwork/maticjs" at "3.9.10"`. New tarball file count back to ~106
- [ ] `npm view @maticnetwork/maticjs@3.9.10 --json | jq .dist.fileCount` returns 100+
- [ ] proof-generation-api install test against `^3.9.10` typechecks cleanly

## Follow-up — separate pipelines PR (recommended)

Patch `pipelines/.github/actions/npm-release/run.sh` (or `apps-npm-release.yml`) to run `pnpm -r run --if-present build` before `changeset publish`. Defends every consumer against forgetting the `prepublishOnly` hook on first release. Today's incident was matic.js's first real release through the canonical workflow; the next consumer's first release will hit the same gotcha unless we add a workflow-level safety net.