### PR TITLE
fix(release): publish README and LICENSE; refresh badges

### DIFF
--- a/.changeset/eleven-houses-try.md
+++ b/.changeset/eleven-houses-try.md
@@ -1,0 +1,15 @@
+---
+'@maticnetwork/maticjs': patch
+---
+
+Ship `README.md` and `LICENSE` in the published npm package.
+
+Previous releases were missing both: the package directory
+(`packages/maticjs/`) had neither file, and npm's auto-include only
+looks at the package directory, not the workspace root. Consumers
+running `npm view @maticnetwork/maticjs readme` saw nothing.
+
+Adds `packages/maticjs/README.md` (consumer-facing, with install,
+docs, source, and support links) and `packages/maticjs/LICENSE`
+(copy of the workspace MIT licence). Both auto-include on publish —
+no `files` field change needed.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Matic SDK
 
-[![GitHub version](https://badge.fury.io/gh/maticnetwork%2Fmatic.js.svg)](https://badge.fury.io/gh/maticnetwork%2Fmatic.js)
-![Build Status](https://github.com/0xPolygon/matic.js/workflows/CI/badge.svg?branch=master)
-[![npm version](https://badge.fury.io/js/%40maticnetwork%2Fmaticjs.svg)](https://badge.fury.io/js/%40maticnetwork%2Fmaticjs)
-![GitHub](https://img.shields.io/github/license/0xPolygon/matic.js)
+[![npm version](https://img.shields.io/npm/v/@maticnetwork/maticjs.svg)](https://www.npmjs.com/package/@maticnetwork/maticjs)
+[![CI](https://github.com/0xPolygon/matic.js/actions/workflows/ci-trigger.yml/badge.svg?branch=master)](https://github.com/0xPolygon/matic.js/actions/workflows/ci-trigger.yml)
+[![Release](https://github.com/0xPolygon/matic.js/actions/workflows/npm-release-trigger.yml/badge.svg?branch=master)](https://github.com/0xPolygon/matic.js/actions/workflows/npm-release-trigger.yml)
+[![License: MIT](https://img.shields.io/npm/l/@maticnetwork/maticjs.svg)](LICENSE)
 
 This repository contains the `maticjs` client library. `maticjs` makes it easy for developers,
 who may not be deeply familiar with smart contract development, to interact with the various
@@ -14,7 +14,7 @@ from Matic to Ethereum using fraud proofs.
 
 ## Docs
 
-[https://wiki.polygon.technology/docs/tools/matic-js/get-started](https://wiki.polygon.technology/docs/tools/matic-js/get-started/)
+[https://docs.polygon.technology/tools/matic-js/get-started](https://docs.polygon.technology/tools/matic-js/get-started)
 
 ## Support
 

--- a/packages/maticjs/LICENSE
+++ b/packages/maticjs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Matic Network
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/maticjs/README.md
+++ b/packages/maticjs/README.md
@@ -1,0 +1,41 @@
+# @maticnetwork/maticjs
+
+[![npm version](https://img.shields.io/npm/v/@maticnetwork/maticjs.svg)](https://www.npmjs.com/package/@maticnetwork/maticjs)
+[![CI](https://github.com/0xPolygon/matic.js/actions/workflows/ci-trigger.yml/badge.svg?branch=master)](https://github.com/0xPolygon/matic.js/actions/workflows/ci-trigger.yml)
+[![Release](https://github.com/0xPolygon/matic.js/actions/workflows/npm-release-trigger.yml/badge.svg?branch=master)](https://github.com/0xPolygon/matic.js/actions/workflows/npm-release-trigger.yml)
+[![License: MIT](https://img.shields.io/npm/l/@maticnetwork/maticjs.svg)](LICENSE)
+
+JavaScript SDK for the Polygon (Matic) Network. Move assets between
+Ethereum and Polygon and withdraw using fraud proofs, without needing
+deep familiarity with the underlying smart contracts.
+
+## Install
+
+```bash
+npm install @maticnetwork/maticjs
+# or
+pnpm add @maticnetwork/maticjs
+```
+
+A plugin is required for the EVM library you use:
+
+- [`@maticnetwork/maticjs-ethers`](https://www.npmjs.com/package/@maticnetwork/maticjs-ethers) — ethers v5
+- [`@maticnetwork/maticjs-web3`](https://www.npmjs.com/package/@maticnetwork/maticjs-web3) — web3.js
+
+## Documentation
+
+<https://docs.polygon.technology/tools/matic-js/get-started>
+
+## Source
+
+<https://github.com/0xPolygon/matic.js> — issues, contributions, and the
+broader monorepo. The published package directory is
+[`packages/maticjs/`](https://github.com/0xPolygon/matic.js/tree/master/packages/maticjs).
+
+## Support
+
+Reach the team on [Discord](https://discord.com/invite/0xpolygonrnd).
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Two fixes that surfaced together after the `3.9.10` release went out:

1. The published npm package was missing `README.md` and `LICENSE`.
2. The badges in the root README were stale (CI showing no status, version stuck at `3.5.0`, npm package version stuck at `3.9.7`).

## Why the package was missing README and LICENSE

`packages/maticjs/` had neither file, and npm's "auto-include README/LICENSE regardless of `files`" rule only looks **inside the package directory** — not the workspace root. So `npm view @maticnetwork/maticjs readme` returns nothing, and the npmjs.com listing has no documentation.

Fix: add `packages/maticjs/README.md` (consumer-focused — install, docs, source, support) and copy the workspace `LICENSE` into `packages/maticjs/LICENSE`. Both auto-include on publish; no change to the `files` field needed.

## Why the badges were stale

| Old badge | Why it broke |
|---|---|
| `badge.fury.io/gh/maticnetwork%2Fmatic.js.svg` ("GitHub version") | Cached a 2022-era `v3.5.0` GitHub Release tag. Releases now use the changesets `<pkg>@<version>` format, which badge.fury.io doesn't pick up. |
| `github.com/0xPolygon/matic.js/workflows/CI/badge.svg` ("Build Status") | Deprecated workflow-name shorthand. Stopped resolving cleanly post-migration to `pipelines`. |
| `badge.fury.io/js/%40maticnetwork%2Fmaticjs.svg` ("npm version") | badge.fury.io's caching is opaque and slow — was stuck on `3.9.7`. |

Replace all three with shields.io badges that pull live from npm and reference the workflow files directly:

```markdown
[![npm version](https://img.shields.io/npm/v/@maticnetwork/maticjs.svg)]…
[![CI](https://github.com/0xPolygon/matic.js/actions/workflows/ci-trigger.yml/badge.svg?branch=master)]…
[![Release](https://github.com/0xPolygon/matic.js/actions/workflows/npm-release-trigger.yml/badge.svg?branch=master)]…
[![License: MIT](https://img.shields.io/npm/l/@maticnetwork/maticjs.svg)](LICENSE)
```

The root README also gains a separate **Release** badge so the npm-release pipeline's status is visible alongside CI.

## Test plan

- [ ] CI green
- [ ] On merge: Release / Deploy PR opens bumping `3.9.10 → 3.9.11`
- [ ] After the 3.9.11 publish: `npm view @maticnetwork/maticjs@3.9.11 readme` returns the consumer README, and the npmjs.com listing shows it
- [ ] All four badges in both READMEs render with live data (npm shows `3.9.11`, CI/Release show current workflow status)