### PR TITLE
fix(ci): drop removed default_branch input from npm-release trigger

### DIFF
--- a/.github/workflows/npm-release-trigger.yml
+++ b/.github/workflows/npm-release-trigger.yml
@@ -23,16 +23,11 @@ permissions:
 jobs:
   release:
     uses: 0xPolygon/pipelines/.github/workflows/apps-npm-release.yml@main
-    # matic.js's default branch is `master`, not `main`. The shared
-    # workflow uses this for the post-publish lockfile commit
-    # (PATCH refs/heads/<branch>) and the pre-tag fast-forward fetch.
-    #
     # `snapshot_tag` is empty on the `push` event (no `inputs.snapshot_tag`
     # to forward), so the reusable workflow runs the standard release
     # job. On `workflow_dispatch` the supplied dist-tag is forwarded
     # and the reusable workflow runs the snapshot job instead.
     with:
-      default_branch: master
       snapshot_tag: ${{ inputs.snapshot_tag || '' }}
     secrets:
       CHANGESET_RELEASE_BOT_APP_ID: ${{ secrets.CHANGESET_RELEASE_BOT_APP_ID }}


### PR DESCRIPTION
## Problem

The `Release` workflow failed at validation on push to `master`:

> The workflow is not valid. `.github/workflows/npm-release-trigger.yml` (Line: 35, Col: 23): Invalid input, default_branch is not defined in the referenced workflow.

The shared reusable workflow `0xPolygon/pipelines/.github/workflows/apps-npm-release.yml` **removed its `default_branch` input** — it now accepts only `snapshot_tag` and derives the branch itself. Our trigger still passed `default_branch: master`, so GitHub rejected the workflow before any job ran. Releases on `master` are blocked until this lands.

## Fix

Remove the `default_branch` input (and its now-stale explanatory comment) from the `with:` block. Only `snapshot_tag` remains, matching the reusable workflow's current input contract. No behavioural change to the release/snapshot logic — the shared workflow already resolves the branch on its own.