### PR TITLE
fix(maticjs): retry transient network errors via a shared retryTransient helper

### DIFF
--- a/.changeset/maticjs-retry-transient-fetch.md
+++ b/.changeset/maticjs-retry-transient-fetch.md
@@ -1,0 +1,5 @@
+---
+'@maticnetwork/maticjs': patch
+---
+
+Retry transient network failures when fetching network/ABI metadata. The config-store fetch (`ABIManager.init` → `HttpRequest`) now retries connection-level errors with exponential backoff, fixing intermittent `Premature close` / `ECONNRESET` failures from stale keep-alive sockets (Node 19+ keeps HTTP connections alive by default) that previously surfaced as a misleading "network mainnet - v1 is not supported". The retry/backoff and transient-error classification are extracted into a shared `retryTransient` helper now used by both the metadata fetch and the receipt-proof RPC reads (replacing the bespoke inline retry in `getReceiptProof`); the shared classifier also recognises node-fetch's `Premature close`, which the old inline predicate missed.

--- a/packages/maticjs/src/utils/http_request.ts
+++ b/packages/maticjs/src/utils/http_request.ts
@@ -1,3 +1,5 @@
+import { retryTransient } from './retry';
+
 const fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response> = (() => {
   if (process.env.BUILD_ENV === 'node') {
     return require('node-fetch').default;
@@ -43,25 +45,31 @@ export class HttpRequest {
         .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`)
         .join('&');
 
-    return fetch(fullUrl, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json'
-      }
-    }).then((res) => parseJsonResponse<T>(res, 'GET', fullUrl));
+    // Retry transient connection failures (a stale keep-alive socket surfaces
+    // as a node-fetch "Premature close" / ECONNRESET while reading the body).
+    return retryTransient(() =>
+      fetch(fullUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        }
+      }).then((res) => parseJsonResponse<T>(res, 'GET', fullUrl))
+    );
   }
 
   post(url = '', body) {
     const fullUrl = this.baseUrl + url;
 
-    return fetch(fullUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json'
-      },
-      body: body ? JSON.stringify(body) : null
-    }).then((res) => parseJsonResponse(res, 'POST', fullUrl));
+    return retryTransient(() =>
+      fetch(fullUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: body ? JSON.stringify(body) : null
+      }).then((res) => parseJsonResponse(res, 'POST', fullUrl))
+    );
   }
 }

--- a/packages/maticjs/src/utils/index.ts
+++ b/packages/maticjs/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './event_bus';
 export * from './logger';
 export * from './merge';
 export * from './map_promise';
+export * from './retry';
 export * from './proof_util';
 export * from './http_request';
 export * from './converter';

--- a/packages/maticjs/src/utils/proof_util.ts
+++ b/packages/maticjs/src/utils/proof_util.ts
@@ -7,7 +7,7 @@ import rlp from 'rlp';
 import type { BaseWeb3Client } from '../abstracts';
 import type { ITransactionReceipt, IBlockWithTransaction } from '../interfaces';
 
-import { Converter, promiseResolve } from '..';
+import { Converter, promiseResolve, retryTransient } from '..';
 import { BufferUtil } from './buffer-utils';
 import { Keccak } from './keccak';
 import { mapPromise } from './map_promise';
@@ -164,40 +164,12 @@ export class ProofUtil {
       });
       receiptPromise = mapPromise(
         txHashes,
-        (hash: string) => {
-          // Retry transient network errors so that a single stale
-          // keep-alive socket or a brief DNS hiccup does not fail the
-          // entire proof.  Node.js 19+ enables keep-alive on the
-          // global HTTPS agent by default; if the server closes an
-          // idle connection while sequential Ethereum RPC calls are
-          // running, the next Polygon receipt fetch hits the stale
-          // socket and receives ECONNRESET.
-          //
-          // Each retry waits a full-jitter exponential backoff delay
-          // in [0, min(2000ms, 250ms * 2^i)] before re-attempting,
-          // so that a burst of simultaneous failures does not hammer
-          // the RPC endpoint with synchronised retries.
-          const MAX_RETRIES = 2;
-          const attempt = (remaining: number): Promise<ITransactionReceipt> =>
-            web3.getTransactionReceipt(hash).catch((err: any) => {
-              const isTransient =
-                err?.code === 'ECONNRESET' ||
-                err?.code === 'ENOTFOUND' ||
-                err?.code === 'ECONNREFUSED' ||
-                err?.code === 'ETIMEDOUT' ||
-                err?.errno === 'ECONNRESET' ||
-                err?.errno === 'ENOTFOUND';
-              if (remaining > 0 && isTransient) {
-                const i = MAX_RETRIES - remaining;
-                const delayMs = Math.random() * Math.min(250, 50 * Math.pow(2, i));
-                return new Promise<void>((resolve) => setTimeout(resolve, delayMs)).then(() =>
-                  attempt(remaining - 1)
-                );
-              }
-              throw err;
-            });
-          return attempt(MAX_RETRIES);
-        },
+        // Retry transient network errors so a single stale keep-alive socket or
+        // a brief DNS hiccup doesn't fail the whole proof. Node.js 19+ keeps
+        // HTTPS connections alive by default, so a server-closed idle socket
+        // surfaces as ECONNRESET (or a node-fetch "Premature close") on the
+        // next reused-socket request — see retryTransient.
+        (hash: string) => retryTransient(() => web3.getTransactionReceipt(hash)),
         {
           concurrency: requestConcurrency
         }

--- a/packages/maticjs/src/utils/retry.ts
+++ b/packages/maticjs/src/utils/retry.ts
@@ -1,0 +1,88 @@
+// Shared helper for retrying transient network failures.
+//
+// Node.js 19+ enables keep-alive on the global HTTP(S) agent by default. When
+// a server closes an idle keep-alive connection, the next request that reuses
+// that socket fails with a transient error (ECONNRESET, or a node-fetch
+// "Premature close" while reading the response body). These are not real
+// failures — a retry on a fresh socket succeeds. This helper centralises both
+// the transient-error classification and the backoff loop so call sites
+// (Ethereum RPC reads, the ABI/config metadata fetch) don't each reimplement it.
+
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET',
+  'ENOTFOUND',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EPIPE',
+  // node-fetch surfaces a prematurely-closed response-body stream with this code.
+  'ERR_STREAM_PREMATURE_CLOSE'
+]);
+
+interface ErrorLike {
+  code?: unknown;
+  errno?: unknown;
+  message?: unknown;
+}
+
+/**
+ * True for connection-level failures that are safe to retry on a fresh socket:
+ * the known transient `code`/`errno` values, plus node-fetch's "Premature
+ * close" / "socket hang up" (which arrive as a wrapped FetchError whose message
+ * — not always its `code` — carries the cause).
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const { code, errno, message } = err as ErrorLike;
+  if (typeof code === 'string' && TRANSIENT_CODES.has(code)) {
+    return true;
+  }
+  if (typeof errno === 'string' && TRANSIENT_CODES.has(errno)) {
+    return true;
+  }
+  if (typeof message === 'string') {
+    const lower = message.toLowerCase();
+    return lower.includes('premature close') || lower.includes('socket hang up');
+  }
+  return false;
+}
+
+export interface RetryOptions {
+  /** Number of retries AFTER the first attempt. Default 2 (so up to 3 tries). */
+  retries?: number;
+  /** Base backoff in ms; the i-th retry waits up to `baseDelayMs * 2^i`. Default 50. */
+  baseDelayMs?: number;
+  /** Upper bound on a single backoff delay, in ms. Default 250. */
+  maxDelayMs?: number;
+  /** Predicate deciding whether an error is retryable. Default: transient network errors. */
+  shouldRetry?: (err: unknown) => boolean;
+}
+
+/**
+ * Run `fn`, retrying on retryable errors with full-jitter exponential backoff.
+ * Full jitter (delay drawn from `[0, cap]`) avoids synchronised retry bursts
+ * when many calls fail at once. Non-retryable errors propagate immediately.
+ */
+export async function retryTransient<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const retries = options.retries ?? 2;
+  const baseDelayMs = options.baseDelayMs ?? 50;
+  const maxDelayMs = options.maxDelayMs ?? 250;
+  const shouldRetry = options.shouldRetry ?? isTransientNetworkError;
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= retries || !shouldRetry(err)) {
+        throw err;
+      }
+      const cap = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+      const delayMs = Math.random() * cap;
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}

--- a/packages/maticjs/tests/retry.test.ts
+++ b/packages/maticjs/tests/retry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the shared transient-retry helper.
+ *
+ * The classification must cover node-fetch's "Premature close" — a wrapped
+ * FetchError that (verified against node-fetch 2.7.0 source) carries
+ * `code === errno === 'ERR_STREAM_PREMATURE_CLOSE'` AND a "...: Premature close"
+ * message. The previous inline predicate in proof_util.ts checked only a fixed
+ * `code` list that omitted it, so the ABI/config metadata fetch failed
+ * un-retried in CI. The real-FetchError case below pins the exact shape.
+ */
+import nodeFetch from 'node-fetch';
+import { describe, expect, it } from 'vitest';
+
+import { isTransientNetworkError, retryTransient } from '../src/utils/retry';
+
+// node-fetch v2 is CommonJS; FetchError hangs off the default export.
+const { FetchError } = nodeFetch as unknown as {
+  FetchError: new (m: string, t: string, s?: unknown) => Error;
+};
+
+describe('isTransientNetworkError', () => {
+  it('matches known transient codes (code or errno)', () => {
+    expect(isTransientNetworkError({ code: 'ECONNRESET' })).toBe(true);
+    expect(isTransientNetworkError({ code: 'ETIMEDOUT' })).toBe(true);
+    expect(isTransientNetworkError({ errno: 'ENOTFOUND' })).toBe(true);
+    expect(isTransientNetworkError({ code: 'ERR_STREAM_PREMATURE_CLOSE' })).toBe(true);
+  });
+
+  it("matches node-fetch's 'Premature close' / 'socket hang up' by message", () => {
+    expect(
+      isTransientNetworkError(
+        new Error(
+          'Invalid response body while trying to fetch https://static.polygon.technology/network/mainnet/v1/index.json: Premature close'
+        )
+      )
+    ).toBe(true);
+    expect(isTransientNetworkError(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('matches a REAL node-fetch FetchError for a premature close', () => {
+    // Built exactly as node-fetch 2.7.0 does it (lib/index.js): an inner
+    // stream error with code ERR_STREAM_PREMATURE_CLOSE, wrapped in a
+    // `system` FetchError — whose ctor copies `code`/`errno` from the inner.
+    const inner = Object.assign(new Error('Premature close'), {
+      code: 'ERR_STREAM_PREMATURE_CLOSE'
+    });
+    const fetchErr = new FetchError(
+      'Invalid response body while trying to fetch https://static.polygon.technology/network/mainnet/v1/index.json: Premature close',
+      'system',
+      inner
+    );
+    // Sanity-check the shape we're relying on, then the classification.
+    expect(fetchErr).to.have.property('code', 'ERR_STREAM_PREMATURE_CLOSE');
+    expect(fetchErr).to.have.property('errno', 'ERR_STREAM_PREMATURE_CLOSE');
+    expect(isTransientNetworkError(fetchErr)).toBe(true);
+  });
+
+  it('does not match application errors (e.g. an HTTP status error)', () => {
+    expect(isTransientNetworkError(new Error('HTTP 403 Forbidden for GET ...'))).toBe(false);
+    expect(isTransientNetworkError({ code: 'EACCES' })).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError('nope')).toBe(false);
+  });
+});
+
+describe('retryTransient', () => {
+  it('retries a transient failure and then succeeds', async () => {
+    let calls = 0;
+    const result = await retryTransient(
+      async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw new Error('Premature close');
+        }
+        return 'ok';
+      },
+      { baseDelayMs: 1, maxDelayMs: 2 }
+    );
+    expect(result).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  it('does not retry a non-transient error', async () => {
+    let calls = 0;
+    await expect(
+      retryTransient(async () => {
+        calls += 1;
+        throw new Error('HTTP 403 Forbidden');
+      })
+    ).rejects.toThrow(/403/);
+    expect(calls).toBe(1);
+  });
+
+  it('gives up after the configured retries and rethrows the last error', async () => {
+    let calls = 0;
+    await expect(
+      retryTransient(
+        async () => {
+          calls += 1;
+          throw new Error('Premature close');
+        },
+        { retries: 2, baseDelayMs: 1, maxDelayMs: 2 }
+      )
+    ).rejects.toThrow(/Premature close/);
+    expect(calls).toBe(3); // initial attempt + 2 retries
+  });
+});


### PR DESCRIPTION
## Problem

The config-store fetch in `ABIManager.init` (via `HttpRequest`) had **no retry**. Node.js 19+ keeps HTTP(S) connections alive by default, so when the server closes an idle keep-alive socket, the next request reusing it dies with a transient error — observed as a node-fetch **`Premature close`** while reading `https://static.polygon.technology/network/mainnet/v1/index.json`. `Web3SideChainClient.init` then masked it as `network mainnet - v1 is not supported` (fixed in #477 to surface the cause — which is how we caught this). It's intermittent and load-sensitive, so it hit CI ~80% of the time while passing locally.

`getReceiptProof` already documents and handles this exact failure class (`ECONNRESET`, …) with a **bespoke inline retry** — but that logic lived only in `proof_util.ts`, and its predicate was **code-only**, so it wouldn't even have matched `Premature close` (a `FetchError` whose *message*, not `code`, carries the cause).

## Fix — one shared helper, no duplicated retry logic

New `utils/retry.ts`:
- **`isTransientNetworkError(err)`** — the known transient codes (`ECONNRESET`, `ENOTFOUND`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`, `ERR_STREAM_PREMATURE_CLOSE`) **plus** message-based matching for node-fetch's `Premature close` / `socket hang up` (the gap that let this bug through).
- **`retryTransient(fn, opts)`** — full-jitter exponential backoff (defaults preserved from the previous inline implementation: 2 retries, `50 * 2^i` capped at 250ms).

Wired in:
- **`http_request.ts`** — `get`/`post` wrap their fetch in `retryTransient` (transient connection failures retried; HTTP-status errors stay non-retried).
- **`proof_util.ts`** — the inline `attempt()` recursion in `getReceiptProof` is replaced by `retryTransient(() => web3.getTransactionReceipt(hash))`. Behaviour preserved, and it now also covers `Premature close`.

## Tests

`tests/retry.test.ts` (6 cases): classification incl. `Premature close`; retry-then-succeed; no-retry on application errors; give-up-and-rethrow. Full package suite: **35 passed**. Typecheck + lint + webpack build green.