### PR TITLE
fix: correct invalid team slug in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0xPolygon/polygon-apps-team
+* @0xPolygon/product-applications


### PR DESCRIPTION
## Summary
- `@0xPolygon/polygon-apps-team` referenced in `.github/CODEOWNERS` is not a real GitHub team (confirmed 404 via the org API) — CODEOWNERS review on this repo could never actually resolve to a reviewer
- Corrected to `@0xPolygon/product-applications`, the actual team backing Apps Team members on GitHub
- Same bug found and fixed identically across `gas-station`, `apps-team-workspace`, and sibling repos in this sweep

## Test plan
- [ ] Confirm GitHub resolves `@0xPolygon/product-applications` as a valid CODEOWNERS entry